### PR TITLE
adding save_dir argument to decode_speech function, fix issue #117

### DIFF
--- a/quail/decode_speech.py
+++ b/quail/decode_speech.py
@@ -243,13 +243,15 @@ def decode_speech(path, keypath=None, save=False, save_dir=None, speech_context=
             raw.append(results)
 
             if save:
+
+                f_name = os.path.split(f)[1]
+                save_path = os.path.abspath(os.path.join(save_dir,f_name))
+
                 # save the raw response in a pickle
-                pickle.dump(words, open(os.path.abspath(os.path.join(
-                save_dir,f)) + ".p", "wb" ))
+                pickle.dump(words, open(save_path + ".p", "wb" ))
 
                 # save a text file with just the words
-                pd.DataFrame(parsed_results).to_csv(os.path.abspath(
-                os.path.join(save_dir,f)) + '.txt', header=False, index=False)
+                pd.DataFrame(parsed_results).to_csv(save_path + '.txt', header=False, index=False)
 
             # print when finished
             print('Finished file ' + str(i+1) + ' of ' + str(len(files)) + ' in '

--- a/quail/decode_speech.py
+++ b/quail/decode_speech.py
@@ -99,7 +99,8 @@ def decode_speech(path, keypath=None, save=False, save_dir=None, speech_context=
             Subfunction that loops over audio segments to recognize speech
             """
             # export as flac
-            chunk.export(file_path + ".flac", format = "flac", bitrate="44.1k")
+            if not os.path.isfile(file_path + ".flac"):
+                chunk.export(file_path + ".flac", format = "flac", bitrate="44.1k")
 
             # open flac file
             with open(file_path + ".flac", 'rb') as sc:

--- a/quail/decode_speech.py
+++ b/quail/decode_speech.py
@@ -248,7 +248,7 @@ def decode_speech(path, keypath=None, save=False, save_dir=None, speech_context=
                 save_path = os.path.abspath(os.path.join(save_dir,f_name))
 
                 # save the raw response in a pickle
-                pickle.dump(words, open(save_path + ".p", "wb" ))
+                pickle.dump(results, open(save_path + ".p", "wb" ))
 
                 # save a text file with just the words
                 pd.DataFrame(parsed_results).to_csv(save_path + '.txt', header=False, index=False)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('requirements.txt') as f:
     REQUIREMENTS = f.read().splitlines()
 
 EXTRAS_REQUIRE={
-    'speech-decoding': ["pydub", "google-cloud-speech<0.31dev,>=0.30.0", "google-auth"],
+    'speech-decoding': ["pydub", "google-cloud-speech", "google-auth"],
     'efficient-learning': ["sqlalchemy"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('requirements.txt') as f:
     REQUIREMENTS = f.read().splitlines()
 
 EXTRAS_REQUIRE={
-    'speech-decoding': ["pydub", "google-cloud-speech<0.31dev,>=0.30.0", "google-cloud>=0.32.0,<0.34.0"],
+    'speech-decoding': ["pydub", "google-cloud-speech<0.31dev,>=0.30.0", "google-auth"],
     'efficient-learning': ["sqlalchemy"],
 }
 


### PR DESCRIPTION
allows the user to pass a path `save_dir` to `quail.decode_speech()`, specifying the output directory for the text file and pickled results object returned by Google Cloud Speech.

Default behavior (`save_dir=None`) is the same as current behavior of saving the transcript and results object to the same directory as the audio file being decoded.

Also fixes issue #117 

