### PR TITLE
PEP 396 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
 sudo: false
+services:
+- xvfb
 python:
 - '2.7'
 - '3.5'
 - '3.6'
 before_script:
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - sleep 3
 install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/quail/__init__.py
+++ b/quail/__init__.py
@@ -1,3 +1,5 @@
+from pkg_resources import get_distribution
+
 from .load import load, load_example_data, load_egg, loadEL
 from .egg import Egg, FriedEgg
 from .analysis.analysis import analyze
@@ -6,3 +8,7 @@ from .helpers import stack_eggs, crack_egg, recmat2egg, df2list
 from .decode_speech import decode_speech
 from .fingerprint import Fingerprint, OptimalPresenter
 from .distance import *
+
+
+__version__ = get_distribution('quail')
+

--- a/quail/__init__.py
+++ b/quail/__init__.py
@@ -10,5 +10,5 @@ from .fingerprint import Fingerprint, OptimalPresenter
 from .distance import *
 
 
-__version__ = get_distribution('quail')
+__version__ = get_distribution('quail').version
 


### PR DESCRIPTION
adds a `__version__` attribute to `__init__.py` (allows checking package version with `import quail; print(quail.__version__)`.  

Uses [`pkg_resources.get_distribution()`](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#getting-or-creating-distributions) to read the version info so we won't have to update it in multiple places for releases.